### PR TITLE
サーバー構築７回目の授業

### DIFF
--- a/06/db-deployment.yaml
+++ b/06/db-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11.8.1-ubi9-rc
+        ports:
+        - containerPort: 3306
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: db-data-storage
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: db-data-storage
+        persistentVolumeClaim:
+          claimName: db-data-pvc

--- a/06/db-pvc.yaml
+++ b/06/db-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/06/db-service.yaml
+++ b/06/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306

--- a/06/kustomization.yaml
+++ b/06/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: default
+
+resources:
+- db-deployment.yaml
+- db-pvc.yaml
+- db-service.yaml
+- secret.yaml
+- wp-deployment.yaml
+- wp-pvc.yaml
+- wp-service.yaml

--- a/06/secret.yaml
+++ b/06/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-secret
+stringData:
+  MYSQL_ROOT_PASSWORD: 'password'
+  MYSQL_DATABASE: 'wordpress'
+  MYSQL_USER: 'wordpress_user'
+  MYSQL_PASSWORD: 'password'
+  WORDPRESS_DB_HOST: 'db:3306'
+  WORDPRESS_DB_USER: 'wordpress_user'
+  WORDPRESS_DB_PASSWORD: 'password'
+  WORDPRESS_DB_NAME: 'wordpress'

--- a/06/wp-deployment.yaml
+++ b/06/wp-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:6.8.1-php8.1-apache
+        ports:
+        - containerPort: 80
+        envFrom:
+          - secretRef:
+              name: wordpress-secret
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        volumeMounts:
+        - name: wp-data-storage
+          mountPath: /var/www/html
+      volumes:
+      - name: wp-data-storage
+        persistentVolumeClaim:
+          claimName: wp-data-pvc

--- a/06/wp-pvc.yaml
+++ b/06/wp-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wp-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/06/wp-service.yaml
+++ b/06/wp-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+spec:
+  type: ClusterIP
+  selector:
+    app: wordpress
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 80

--- a/06/作業ログ07.md
+++ b/06/作業ログ07.md
@@ -1,0 +1,17 @@
+## 7回目の授業
+```bash
+
+# 6回目の授業でやったnginxのmanifestファイルを確認してみる
+helm template kdg-server-nginx bitnami/nginx
+
+# aquaでkustomizeを入れる
+aqua g -i
+
+aqua i -l
+
+# ビルドしてクラスタに適用
+kustomize build . |kubectl apply -f -
+
+# クラスタに展開したサービスにアクセス出来るようにする
+kubectl port-forward service/wordpress 8080:8080
+```

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -15,3 +15,4 @@ packages:
 - name: derailed/k9s@v0.50.6
 - name: kubernetes/kubernetes/kubectl@v1.33.2
 - name: helm/helm@v3.18.3
+- name: kubernetes-sigs/kustomize@kustomize/v5.7.0


### PR DESCRIPTION
## なぜやるか
- docker composeのファイル群をk8sで動かすため
- k8sのmanifestについて学ぶため
## なにをやったのか
- wordpressが動くcomposeファイルに対応するmanifestを書いた
- ブラウザで http://localhost:8080/ にアクセスして確認した
<img width="1470" alt="スクリーンショット 2025-07-10 18 22 04" src="https://github.com/user-attachments/assets/3b1c5b08-1b7c-4801-a982-9ee4bb8682db" />

## 参考記事
- https://qiita.com/minodisk/items/547741b73763f2bab6b8

## 動作確認の手順
```
# aquaでkustomizeを入れる
aqua g -i

aqua i -l

kustomize build . |kubectl apply -f -

kubectl port-forward service/wordpress 8080:8080
```