### PR TITLE
サーバー構築８回目の授業

### DIFF
--- a/06/db-deployment.yaml
+++ b/06/db-deployment.yaml
@@ -20,13 +20,20 @@ spec:
         envFrom:
           - secretRef:
               name: wordpress-secret
+        # resources:
+        #   requests:
+        #     memory: "256Mi"
+        #     cpu: "250m"
+        #   limits:
+        #     memory: "512Mi"
+        #     cpu: "500m"
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "250m"
+            memory: "300Mi"
+            cpu: "300m"
           limits:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "900Mi"
+            cpu: "600m"
         volumeMounts:
         - name: db-data-storage
           mountPath: /var/lib/mysql

--- a/06/db-deployment.yaml
+++ b/06/db-deployment.yaml
@@ -20,20 +20,13 @@ spec:
         envFrom:
           - secretRef:
               name: wordpress-secret
-        # resources:
-        #   requests:
-        #     memory: "256Mi"
-        #     cpu: "250m"
-        #   limits:
-        #     memory: "512Mi"
-        #     cpu: "500m"
         resources:
           requests:
-            memory: "300Mi"
-            cpu: "300m"
+            cpu: "100m"
+            memory: "372Mi"
           limits:
-            memory: "900Mi"
-            cpu: "600m"
+            cpu: "300m"
+            memory: "1280Mi"
         volumeMounts:
         - name: db-data-storage
           mountPath: /var/lib/mysql

--- a/06/wp-deployment.yaml
+++ b/06/wp-deployment.yaml
@@ -20,20 +20,14 @@ spec:
         envFrom:
           - secretRef:
               name: wordpress-secret
-        # resources:
-        #   requests:
-        #     memory: "256Mi"
-        #     cpu: "250m"
-        #   limits:
-        #     memory: "512Mi"
-        #     cpu: "500m"
+
         resources:
           requests:
-            memory: "200Mi"
-            cpu: "300m"
+            cpu: "350m"
+            memory: "256Mi"
           limits:
-            memory: "600Mi"
-            cpu: "600m"
+            cpu: "1050m"
+            memory: "768Mi"
         volumeMounts:
         - name: wp-data-storage
           mountPath: /var/www/html

--- a/06/wp-deployment.yaml
+++ b/06/wp-deployment.yaml
@@ -20,13 +20,20 @@ spec:
         envFrom:
           - secretRef:
               name: wordpress-secret
+        # resources:
+        #   requests:
+        #     memory: "256Mi"
+        #     cpu: "250m"
+        #   limits:
+        #     memory: "512Mi"
+        #     cpu: "500m"
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "250m"
+            memory: "200Mi"
+            cpu: "300m"
           limits:
-            memory: "512Mi"
-            cpu: "500m"
+            memory: "600Mi"
+            cpu: "600m"
         volumeMounts:
         - name: wp-data-storage
           mountPath: /var/www/html

--- a/06/作業ログ08.md
+++ b/06/作業ログ08.md
@@ -1,0 +1,17 @@
+## 8回目の授業
+```bash
+# k8s クラスタに接続できることを確認する
+kubectl cluster-info
+kubectl get nodes
+
+# kind で pod のリソースが確認できるようにするために metrics-server をデプロイ
+kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml
+
+# wordpress にアクセスできるように port-fowward する
+kubectl port-forward service/wordpress 8080:8080 > /dev/null
+
+# 別のterminalタブでcurlを使ってローカルサーバーに負荷を掛ける
+while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done
+
+kubectl top pods
+```

--- a/06/作業ログ08.md
+++ b/06/作業ログ08.md
@@ -14,4 +14,7 @@ kubectl port-forward service/wordpress 8080:8080 > /dev/null
 while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done
 
 kubectl top pods
+
+# k8sクラスターに設定を適用する
+kustomize build . |kubectl apply -f -
 ```


### PR DESCRIPTION
## なぜやるか
- k8sで構築するサーバーの安定性とパフォーマンス向上のため
## なにをやったのか
- 前回の授業で構築したk8sのwordpressでdeploymentの設定項目を見直す
- ループでHTTPリクエストを連続送信し、WordPressに負荷をかけて、CPUやメモリの使用量を確認した
<img width="466" height="64" alt="スクリーンショット 2025-07-30 17 51 21" src="https://github.com/user-attachments/assets/2d0057e7-eaf0-4c7a-bea5-f8c18687978e" />

## 参考記事
- https://gitlab-docs.creationline.com/ee/ci/

## 動作確認の手順
```
kubectl get nodes

kubectl apply -f https://raw.githubusercontent.com/kdg-server-2025/server-honahuku/refs/heads/main/metrics-server.yaml

kubectl port-forward service/wordpress 8080:8080 > /dev/null

while true; do curl http://localhost:8080/ > /dev/null; sleep 0.1; done

kubectl top pods
```